### PR TITLE
docs: added examples for multi rules definition in rule_group_recording/alerting

### DIFF
--- a/examples/resources/loki_rule_group_alerting/resource.tf
+++ b/examples/resources/loki_rule_group_alerting/resource.tf
@@ -8,6 +8,25 @@ sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
   /
 sum(rate({app="foo", env="production"}[5m])) by (job)
   > 0.05
+EOT
+    for         = "10m"
+    labels      = {
+      severity = "warning"
+    }
+    annotations = {
+      summary = "High request latency"
+    }
+  }
+
+  # can define multiple rules
+  rule {
+    alert       = "HighPercentageError"
+    expr        = <<EOT
+sum(rate({app="bar", env="dev"} |= "error" [5m])) by (job)
+  /
+sum(rate({app="bar", env="dev"}[5m])) by (job)
+  > 0.05
+EOT
     for         = "10m"
     labels      = {
       severity = "warning"

--- a/examples/resources/loki_rule_group_recording/resource.tf
+++ b/examples/resources/loki_rule_group_recording/resource.tf
@@ -5,4 +5,13 @@ resource "loki_rule_group_recording" "test" {
     expr   = "sum by (job) (http_inprogress_requests)"
     record = "job:http_inprogress_requests:sum"
   }
+
+  # can define multiple rules
+  rule {
+    expr   = "max by (job) (http_inprogress_requests)"
+    record = "job:http_inprogress_requests:max"
+    labels      = {
+      foo = "bar"
+    }
+  }
 }


### PR DESCRIPTION
Hi, first of all thanks for this provider, comes in really handy 😄 !

# Description
This PR provides examples on how to define multiple rules in the `loki_rule_group_recording` and `loki_rule_group_alerting` resources.
