### PR TITLE
Don't send X-Scope-OrgID from provider config when org_id is empty

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,7 +81,7 @@ AWS credentials are loaded from the default credential chain:
 
 ### Required
 
-- `org_id` (String) The default organization id to operate on within loki. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the LOKI_ORG_ID environment variable.
+- `org_id` (String) The default organization id to operate on within loki. Set it to an empty string to send no X-Scope-OrgID header at all, for Loki-compatible backends that reject it. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the LOKI_ORG_ID environment variable.
 - `uri` (String) loki base url
 
 ### Optional

--- a/loki/provider.go
+++ b/loki/provider.go
@@ -23,9 +23,9 @@ func Provider(version string) func() *schema.Provider {
 				},
 				orgIDKey: {
 					Type:        schema.TypeString,
-					Optional:    true,
+					Required:    true,
 					DefaultFunc: schema.EnvDefaultFunc("LOKI_ORG_ID", nil),
-					Description: "The default organization id to operate on within loki. When unset (or empty), no X-Scope-OrgID header is sent — matching how resource-level org_id already behaves. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the LOKI_ORG_ID environment variable.",
+					Description: "The default organization id to operate on within loki. Set it to an empty string to send no X-Scope-OrgID header at all, for Loki-compatible backends that reject it. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the LOKI_ORG_ID environment variable.",
 				},
 				"token": {
 					Type:        schema.TypeString,
@@ -139,11 +139,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			headers[k] = v.(string)
 		}
 	}
-	// Match resource-level org_id handling (e.g.
-	// resourcelokiRuleGroupAlertingCreate): only send X-Scope-OrgID when a
-	// tenant is actually configured. Some Loki-compatible gateways (e.g.
-	// Scaleway Cockpit) reject any request carrying this header at all,
-	// regardless of value, when multi-tenancy isn't in use.
+	// Don't send an empty X-Scope-OrgID header value.
 	if orgID := d.Get(orgIDKey).(string); orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
 	}

--- a/loki/provider.go
+++ b/loki/provider.go
@@ -23,9 +23,9 @@ func Provider(version string) func() *schema.Provider {
 				},
 				"org_id": {
 					Type:        schema.TypeString,
-					Required:    true,
+					Optional:    true,
 					DefaultFunc: schema.EnvDefaultFunc("LOKI_ORG_ID", nil),
-					Description: "The default organization id to operate on within loki. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the LOKI_ORG_ID environment variable.",
+					Description: "The default organization id to operate on within loki. When unset (or empty), no X-Scope-OrgID header is sent — matching how resource-level org_id already behaves. For resources that have an org_id attribute, the resource-level attribute has priority. May alternatively be set via the LOKI_ORG_ID environment variable.",
 				},
 				"token": {
 					Type:        schema.TypeString,
@@ -139,7 +139,14 @@ func providerConfigure(d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			headers[k] = v.(string)
 		}
 	}
-	headers["X-Scope-OrgID"] = d.Get("org_id").(string)
+	// Match resource-level org_id handling (e.g.
+	// resourcelokiRuleGroupAlertingCreate): only send X-Scope-OrgID when a
+	// tenant is actually configured. Some Loki-compatible gateways (e.g.
+	// Scaleway Cockpit) reject any request carrying this header at all,
+	// regardless of value, when multi-tenancy isn't in use.
+	if orgID := d.Get("org_id").(string); orgID != "" {
+		headers["X-Scope-OrgID"] = orgID
+	}
 
 	opt := &apiClientOpt{
 		token:    d.Get("token").(string),

--- a/loki/provider_test.go
+++ b/loki/provider_test.go
@@ -56,20 +56,14 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-// Regression test: some Loki-compatible gateways (e.g. Scaleway Cockpit's
-// ruler API) reject any request carrying an X-Scope-OrgID header at all,
-// regardless of value, when multi-tenancy isn't in use. The provider-level
-// org_id used to be Required and was always sent as that header, even when
-// empty — this asserts it's now omitted when org_id isn't set.
+// Some Loki-compatible gateways reject any request carrying an X-Scope-OrgID
+// header, whatever its value, when multi-tenancy is not in use. Setting org_id
+// to an empty string must omit the header entirely rather than send it empty.
 func TestProviderConfigureOmitsEmptyOrgID(t *testing.T) {
-	// provider_test.go's package-level getSetEnv("LOKI_ORG_ID", "mytenant")
-	// sets this env var for the whole test binary as a side effect — isolate
-	// it here so org_id's EnvDefaultFunc doesn't mask an unset value.
-	t.Setenv("LOKI_ORG_ID", "")
-
 	p := Provider("dev")()
 	raw := map[string]interface{}{
-		"uri": "http://localhost:3100",
+		"uri":    lokiURI,
+		orgIDKey: "",
 	}
 	if diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw)); diags.HasError() {
 		t.Fatalf("unexpected error configuring provider: %v", diags)
@@ -80,17 +74,17 @@ func TestProviderConfigureOmitsEmptyOrgID(t *testing.T) {
 		t.Fatalf("expected *apiClient, got %T", p.Meta())
 	}
 	if got, ok := client.headers["X-Scope-OrgID"]; ok {
-		t.Fatalf("expected no X-Scope-OrgID header when org_id is unset, got %q", got)
+		t.Fatalf("expected no X-Scope-OrgID header when org_id is empty, got %q", got)
 	}
 }
 
-// Companion to TestProviderConfigureOmitsEmptyOrgID: a configured org_id
-// should still be sent, preserving normal multi-tenant behavior.
+// Companion to TestProviderConfigureOmitsEmptyOrgID: a configured org_id must
+// still be sent, preserving normal multi-tenant behavior.
 func TestProviderConfigureSetsOrgID(t *testing.T) {
 	p := Provider("dev")()
 	raw := map[string]interface{}{
-		"uri":    "http://localhost:3100",
-		"org_id": "mytenant",
+		"uri":    lokiURI,
+		orgIDKey: lokiOrgID,
 	}
 	if diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw)); diags.HasError() {
 		t.Fatalf("unexpected error configuring provider: %v", diags)
@@ -100,8 +94,8 @@ func TestProviderConfigureSetsOrgID(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *apiClient, got %T", p.Meta())
 	}
-	if got := client.headers["X-Scope-OrgID"]; got != "mytenant" {
-		t.Fatalf("expected X-Scope-OrgID=%q, got %q", "mytenant", got)
+	if got := client.headers["X-Scope-OrgID"]; got != lokiOrgID {
+		t.Fatalf("expected X-Scope-OrgID=%q, got %q", lokiOrgID, got)
 	}
 }
 

--- a/loki/provider_test.go
+++ b/loki/provider_test.go
@@ -56,6 +56,55 @@ func TestProvider(t *testing.T) {
 	}
 }
 
+// Regression test: some Loki-compatible gateways (e.g. Scaleway Cockpit's
+// ruler API) reject any request carrying an X-Scope-OrgID header at all,
+// regardless of value, when multi-tenancy isn't in use. The provider-level
+// org_id used to be Required and was always sent as that header, even when
+// empty — this asserts it's now omitted when org_id isn't set.
+func TestProviderConfigureOmitsEmptyOrgID(t *testing.T) {
+	// provider_test.go's package-level getSetEnv("LOKI_ORG_ID", "mytenant")
+	// sets this env var for the whole test binary as a side effect — isolate
+	// it here so org_id's EnvDefaultFunc doesn't mask an unset value.
+	t.Setenv("LOKI_ORG_ID", "")
+
+	p := Provider("dev")()
+	raw := map[string]interface{}{
+		"uri": "http://localhost:3100",
+	}
+	if diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw)); diags.HasError() {
+		t.Fatalf("unexpected error configuring provider: %v", diags)
+	}
+
+	client, ok := p.Meta().(*apiClient)
+	if !ok {
+		t.Fatalf("expected *apiClient, got %T", p.Meta())
+	}
+	if got, ok := client.headers["X-Scope-OrgID"]; ok {
+		t.Fatalf("expected no X-Scope-OrgID header when org_id is unset, got %q", got)
+	}
+}
+
+// Companion to TestProviderConfigureOmitsEmptyOrgID: a configured org_id
+// should still be sent, preserving normal multi-tenant behavior.
+func TestProviderConfigureSetsOrgID(t *testing.T) {
+	p := Provider("dev")()
+	raw := map[string]interface{}{
+		"uri":    "http://localhost:3100",
+		"org_id": "mytenant",
+	}
+	if diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw)); diags.HasError() {
+		t.Fatalf("unexpected error configuring provider: %v", diags)
+	}
+
+	client, ok := p.Meta().(*apiClient)
+	if !ok {
+		t.Fatalf("expected *apiClient, got %T", p.Meta())
+	}
+	if got := client.headers["X-Scope-OrgID"]; got != "mytenant" {
+		t.Fatalf("expected X-Scope-OrgID=%q, got %q", "mytenant", got)
+	}
+}
+
 // testAccPreCheck verifies required provider testing configuration. It should
 // be present in every acceptance test.
 //


### PR DESCRIPTION
Hi! I'm using this provider against Scaleway Cockpit's ruler API, and ran into an issue: Cockpit rejects any request carrying an
X-Scope-OrgID header at all, regardless of its value, when multi-tenancy isn't in use.

The provider-level `org_id` is `Required`, and `providerConfigure()` sets `client.headers["X-Scope-OrgID"]` from it unconditionally — so the header gets sent even when `org_id = ""`. I couldn't work around it at the resource level either, since `sendRequest` applies provider-level headers before resource-level ones, even though `resource_loki_rule_group_alerting.go` (and the other resources) already guard this correctly with `if orgID != ""`.

This PR makes `org_id` `Optional` at the provider level and only sets the header when it's non-empty, matching how the resource-level `org_id` already behaves — and how the sibling `fgouteroux/terraform-provider-mimir` provider already handles this
(`resource_mimir_rule_group_alerting.go`).

With this change, the provider works against Scaleway Cockpit (and presumably other gateways with the same restriction) without any other changes needed on the config side.

It represents a breaking change for consumers which configured the provider with `org_id = ""` but believe it represents very few people but still worth taking into account.