### PR TITLE
chore: fix golangci-lint failures

### DIFF
--- a/loki/api_client_test.go
+++ b/loki/api_client_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -337,8 +338,8 @@ func setupAPIClientServerWithSigV4Check(debug bool, address string) {
 		}
 
 		if debug {
-			log.Printf("SigV4 Auth Header: %s\n", auth)
-			log.Printf("X-Amz-Date Header: %s\n", xAmzDate)
+			log.Printf("SigV4 Auth Header: %s\n", strconv.Quote(auth))
+			log.Printf("X-Amz-Date Header: %s\n", strconv.Quote(xAmzDate))
 		}
 
 		_, _ = w.Write([]byte("SigV4 OK!"))

--- a/loki/constants.go
+++ b/loki/constants.go
@@ -1,0 +1,9 @@
+package loki
+
+const (
+	orgIDKey         = "org_id"
+	orgIDDescription = "The Organization ID. If not set, the Org ID defined in the provider block will be used."
+	namespaceKey     = "namespace"
+	intervalKey      = "interval"
+	labelsKey        = "labels"
+)

--- a/loki/data_source_loki_rule_group_alerting.go
+++ b/loki/data_source_loki_rule_group_alerting.go
@@ -15,13 +15,13 @@ func dataSourcelokiRuleGroupAlerting() *schema.Resource {
 		ReadContext: dataSourcelokiRuleGroupAlertingRead,
 
 		Schema: map[string]*schema.Schema{
-			"org_id": {
+			orgIDKey: {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+				Description: orgIDDescription,
 			},
-			"namespace": {
+			namespaceKey: {
 				Type:        schema.TypeString,
 				Description: "Alerting Rule group namespace",
 				ForceNew:    true,
@@ -35,7 +35,7 @@ func dataSourcelokiRuleGroupAlerting() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateGroupRuleName,
 			},
-			"interval": {
+			intervalKey: {
 				Type:        schema.TypeString,
 				Description: "Alerting Rule group interval",
 				Computed:    true,
@@ -73,7 +73,7 @@ func dataSourcelokiRuleGroupAlerting() *schema.Resource {
 							Elem:        &schema.Schema{Type: schema.TypeString},
 							Computed:    true,
 						},
-						"labels": {
+						labelsKey: {
 							Type:        schema.TypeMap,
 							Description: "Alerting Rule labels",
 							Elem:        &schema.Schema{Type: schema.TypeString},
@@ -90,8 +90,8 @@ func dataSourcelokiRuleGroupAlerting() *schema.Resource {
 func dataSourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	id := fmt.Sprintf("%s/%s", namespace, name)
 
@@ -123,7 +123,7 @@ func dataSourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.Resource
 	if err := d.Set("rule", flattenAlertingRules(data.Rules)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("interval", data.Interval); err != nil {
+	if err := d.Set(intervalKey, data.Interval); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/loki/data_source_loki_rule_group_list.go
+++ b/loki/data_source_loki_rule_group_list.go
@@ -20,18 +20,18 @@ func dataSourcelokiRuleGroupList() *schema.Resource {
 				Optional:    true,
 				Description: "Name of the datasource. Only used for resource dependency.",
 			},
-			"org_id": {
+			orgIDKey: {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+				Description: orgIDDescription,
 			},
 			"namespaces": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"namespace": {
+						namespaceKey: {
 							Type:        schema.TypeString,
 							Description: "Rule group namespace",
 							Computed:    true,
@@ -46,7 +46,7 @@ func dataSourcelokiRuleGroupList() *schema.Resource {
 										Description: "Rule group name",
 										Computed:    true,
 									},
-									"interval": {
+									intervalKey: {
 										Type:        schema.TypeString,
 										Description: "Rule group interval",
 										Computed:    true,
@@ -82,7 +82,7 @@ func dataSourcelokiRuleGroupList() *schema.Resource {
 													Elem:        &schema.Schema{Type: schema.TypeString},
 													Computed:    true,
 												},
-												"labels": {
+												labelsKey: {
 													Type:        schema.TypeMap,
 													Description: "Rule labels",
 													Elem:        &schema.Schema{Type: schema.TypeString},
@@ -104,7 +104,7 @@ func dataSourcelokiRuleGroupList() *schema.Resource {
 
 func dataSourcelokiRuleGroupListAll(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
-	orgID := d.Get("org_id").(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	id := "all_rules"
 
@@ -147,7 +147,7 @@ func flattenAllRule(v map[string][]ruleGroup) []map[string]interface{} {
 
 	for k, v := range v {
 		namespace := make(map[string]interface{})
-		namespace["namespace"] = k
+		namespace[namespaceKey] = k
 		namespace["rule_groups"] = flattenRuleGroups(v)
 
 		namespaces = append(namespaces, namespace)
@@ -166,7 +166,7 @@ func flattenRuleGroups(v []ruleGroup) []map[string]interface{} {
 	for _, v := range v {
 		ruleGroup := make(map[string]interface{})
 		ruleGroup["name"] = v.Name
-		ruleGroup["interval"] = v.Interval
+		ruleGroup[intervalKey] = v.Interval
 		ruleGroup["rule"] = flattenRules(v.Rules)
 
 		ruleGroups = append(ruleGroups, ruleGroup)
@@ -192,7 +192,7 @@ func flattenRules(v []rule) []map[string]interface{} {
 			rule["for"] = v.For
 		}
 		if v.Labels != nil {
-			rule["labels"] = v.Labels
+			rule[labelsKey] = v.Labels
 		}
 		if v.Annotations != nil {
 			rule["annotations"] = v.Annotations

--- a/loki/data_source_loki_rule_group_recording.go
+++ b/loki/data_source_loki_rule_group_recording.go
@@ -15,13 +15,13 @@ func dataSourcelokiRuleGroupRecording() *schema.Resource {
 		ReadContext: dataSourcelokiRuleGroupRecordingRead,
 
 		Schema: map[string]*schema.Schema{
-			"org_id": {
+			orgIDKey: {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+				Description: orgIDDescription,
 			},
-			"namespace": {
+			namespaceKey: {
 				Type:        schema.TypeString,
 				Description: "Recording Rule group namespace",
 				ForceNew:    true,
@@ -35,7 +35,7 @@ func dataSourcelokiRuleGroupRecording() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateGroupRuleName,
 			},
-			"interval": {
+			intervalKey: {
 				Type:        schema.TypeString,
 				Description: "Recording Rule group interval",
 				Computed:    true,
@@ -53,7 +53,7 @@ func dataSourcelokiRuleGroupRecording() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
-						"labels": {
+						labelsKey: {
 							Type:        schema.TypeMap,
 							Description: "Alerting Rule labels",
 							Elem:        &schema.Schema{Type: schema.TypeString},
@@ -70,8 +70,8 @@ func dataSourcelokiRuleGroupRecording() *schema.Resource {
 func dataSourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	id := fmt.Sprintf("%s/%s", namespace, name)
 
@@ -103,7 +103,7 @@ func dataSourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.Resourc
 	if err := d.Set("rule", flattenRecordingRules(data.Rules)); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set("interval", data.Interval); err != nil {
+	if err := d.Set(intervalKey, data.Interval); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/loki/provider.go
+++ b/loki/provider.go
@@ -21,7 +21,7 @@ func Provider(version string) func() *schema.Provider {
 					DefaultFunc: schema.EnvDefaultFunc("LOKI_URI", nil),
 					Description: "loki base url",
 				},
-				"org_id": {
+				orgIDKey: {
 					Type:        schema.TypeString,
 					Required:    true,
 					DefaultFunc: schema.EnvDefaultFunc("LOKI_ORG_ID", nil),
@@ -139,7 +139,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 			headers[k] = v.(string)
 		}
 	}
-	headers["X-Scope-OrgID"] = d.Get("org_id").(string)
+	headers["X-Scope-OrgID"] = d.Get(orgIDKey).(string)
 
 	opt := &apiClientOpt{
 		token:    d.Get("token").(string),

--- a/loki/resource_loki_rule_group_alerting.go
+++ b/loki/resource_loki_rule_group_alerting.go
@@ -20,13 +20,13 @@ func resourcelokiRuleGroupAlerting() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
-			"org_id": {
+			orgIDKey: {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+				Description: orgIDDescription,
 			},
-			"namespace": {
+			namespaceKey: {
 				Type:        schema.TypeString,
 				Description: "Alerting Rule group namespace",
 				ForceNew:    true,
@@ -40,7 +40,7 @@ func resourcelokiRuleGroupAlerting() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateGroupRuleName,
 			},
-			"interval": {
+			intervalKey: {
 				Type:         schema.TypeString,
 				Description:  "Alerting Rule group interval",
 				Optional:     true,
@@ -86,7 +86,7 @@ func resourcelokiRuleGroupAlerting() *schema.Resource {
 							Elem:         &schema.Schema{Type: schema.TypeString},
 							ValidateFunc: validateAnnotations,
 						},
-						"labels": {
+						labelsKey: {
 							Type:         schema.TypeMap,
 							Description:  "Labels to add or overwrite for each alert.",
 							Optional:     true,
@@ -103,12 +103,12 @@ func resourcelokiRuleGroupAlerting() *schema.Resource {
 func resourcelokiRuleGroupAlertingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	rules := &alertingRuleGroup{
 		Name:     name,
-		Interval: d.Get("interval").(string),
+		Interval: d.Get(intervalKey).(string),
 		Rules:    expandAlertingRules(d.Get("rule").([]interface{})),
 	}
 	data, _ := yaml.Marshal(rules)
@@ -175,7 +175,7 @@ func resourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(fmt.Errorf("unable to decode alerting namespace rule group '%s' data: %v", name, err))
 	}
 
-	err = d.Set("org_id", orgID)
+	err = d.Set(orgIDKey, orgID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -184,7 +184,7 @@ func resourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceDa
 		return diag.FromErr(err)
 	}
 
-	err = d.Set("namespace", namespace)
+	err = d.Set(namespaceKey, namespace)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -192,7 +192,7 @@ func resourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceDa
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	err = d.Set("interval", data.Interval)
+	err = d.Set(intervalKey, data.Interval)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -201,15 +201,15 @@ func resourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourcelokiRuleGroupAlertingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChanges("rule", "interval") {
+	if d.HasChanges("rule", intervalKey) {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
-		namespace := d.Get("namespace").(string)
-		orgID := d.Get("org_id").(string)
+		namespace := d.Get(namespaceKey).(string)
+		orgID := d.Get(orgIDKey).(string)
 
 		rules := &alertingRuleGroup{
 			Name:     name,
-			Interval: d.Get("interval").(string),
+			Interval: d.Get(intervalKey).(string),
 			Rules:    expandAlertingRules(d.Get("rule").([]interface{})),
 		}
 		data, _ := yaml.Marshal(rules)
@@ -232,8 +232,8 @@ func resourcelokiRuleGroupAlertingUpdate(ctx context.Context, d *schema.Resource
 func resourcelokiRuleGroupAlertingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 	headers := make(map[string]string)
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
@@ -280,7 +280,7 @@ func expandAlertingRules(v []interface{}) []alertingRule {
 			}
 		*/
 
-		if raw, ok := data["labels"]; ok {
+		if raw, ok := data[labelsKey]; ok {
 			if len(raw.(map[string]interface{})) > 0 {
 				rule.Labels = expandStringMap(raw.(map[string]interface{}))
 			}
@@ -319,7 +319,7 @@ func flattenAlertingRules(v []alertingRule) []map[string]interface{} {
 			}
 		*/
 		if v.Labels != nil {
-			rule["labels"] = v.Labels
+			rule[labelsKey] = v.Labels
 		}
 		if v.Annotations != nil {
 			rule["annotations"] = v.Annotations

--- a/loki/resource_loki_rule_group_recording.go
+++ b/loki/resource_loki_rule_group_recording.go
@@ -20,13 +20,13 @@ func resourcelokiRuleGroupRecording() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: map[string]*schema.Schema{
-			"org_id": {
+			orgIDKey: {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+				Description: orgIDDescription,
 			},
-			"namespace": {
+			namespaceKey: {
 				Type:        schema.TypeString,
 				Description: "Recording Rule group namespace",
 				ForceNew:    true,
@@ -40,7 +40,7 @@ func resourcelokiRuleGroupRecording() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: validateGroupRuleName,
 			},
-			"interval": {
+			intervalKey: {
 				Type:         schema.TypeString,
 				Description:  "Recording Rule group interval",
 				Optional:     true,
@@ -63,7 +63,7 @@ func resourcelokiRuleGroupRecording() *schema.Resource {
 							Description:  "The LogQL expression to evaluate.",
 							ValidateFunc: validateLogQLExpr,
 						},
-						"labels": {
+						labelsKey: {
 							Type:         schema.TypeMap,
 							Description:  "Labels to add or overwrite before storing the result.",
 							Optional:     true,
@@ -80,12 +80,12 @@ func resourcelokiRuleGroupRecording() *schema.Resource {
 func resourcelokiRuleGroupRecordingCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	rules := &recordingRuleGroup{
 		Name:     name,
-		Interval: d.Get("interval").(string),
+		Interval: d.Get(intervalKey).(string),
 		Rules:    expandRecordingRules(d.Get("rule").([]interface{})),
 	}
 	data, _ := yaml.Marshal(rules)
@@ -152,7 +152,7 @@ func resourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(fmt.Errorf("unable to decode recording namespace rule group '%s' data: %v", name, err))
 	}
 
-	err = d.Set("org_id", orgID)
+	err = d.Set(orgIDKey, orgID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -161,7 +161,7 @@ func resourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	err = d.Set("namespace", namespace)
+	err = d.Set(namespaceKey, namespace)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -171,7 +171,7 @@ func resourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceD
 		return diag.FromErr(err)
 	}
 
-	err = d.Set("interval", data.Interval)
+	err = d.Set(intervalKey, data.Interval)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -180,15 +180,15 @@ func resourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceD
 }
 
 func resourcelokiRuleGroupRecordingUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	if d.HasChanges("rule", "interval") {
+	if d.HasChanges("rule", intervalKey) {
 		client := meta.(*apiClient)
 		name := d.Get("name").(string)
-		namespace := d.Get("namespace").(string)
-		orgID := d.Get("org_id").(string)
+		namespace := d.Get(namespaceKey).(string)
+		orgID := d.Get(orgIDKey).(string)
 
 		rules := &recordingRuleGroup{
 			Name:     name,
-			Interval: d.Get("interval").(string),
+			Interval: d.Get(intervalKey).(string),
 			Rules:    expandRecordingRules(d.Get("rule").([]interface{})),
 		}
 		data, _ := yaml.Marshal(rules)
@@ -211,8 +211,8 @@ func resourcelokiRuleGroupRecordingUpdate(ctx context.Context, d *schema.Resourc
 func resourcelokiRuleGroupRecordingDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*apiClient)
 	name := d.Get("name").(string)
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 	headers := make(map[string]string)
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
@@ -246,7 +246,7 @@ func expandRecordingRules(v []interface{}) []recordingRule {
 			rule.Expr = raw.(string)
 		}
 
-		if raw, ok := data["labels"]; ok {
+		if raw, ok := data[labelsKey]; ok {
 			if len(raw.(map[string]interface{})) > 0 {
 				rule.Labels = expandStringMap(raw.(map[string]interface{}))
 			}
@@ -271,7 +271,7 @@ func flattenRecordingRules(v []recordingRule) []map[string]interface{} {
 		rule["expr"] = v.Expr
 
 		if v.Labels != nil {
-			rule["labels"] = v.Labels
+			rule[labelsKey] = v.Labels
 		}
 
 		rules = append(rules, rule)

--- a/loki/resource_loki_rules.go
+++ b/loki/resource_loki_rules.go
@@ -62,7 +62,7 @@ func resourcelokiRules() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"namespace": {
+			namespaceKey: {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
@@ -70,11 +70,11 @@ func resourcelokiRules() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 100),
 			},
 
-			"org_id": {
+			orgIDKey: {
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Optional:    true,
-				Description: "The Organization ID. If not set, the Org ID defined in the provider block will be used.",
+				Description: orgIDDescription,
 			},
 
 			// Content input methods (mutually exclusive)
@@ -155,7 +155,7 @@ func resourcelokiRules() *schema.Resource {
 							Computed:    true,
 							Description: "Rule group name",
 						},
-						"interval": {
+						intervalKey: {
 							Type:        schema.TypeString,
 							Computed:    true,
 							Description: "Evaluation interval",
@@ -424,8 +424,8 @@ func resourcelokiRulesCreate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	// Determine which groups to manage
 	managedGroups := determineGroupsToManage(ruleGroups, d)
@@ -466,8 +466,8 @@ func resourcelokiRulesCreate(ctx context.Context, d *schema.ResourceData, m inte
 func resourcelokiRulesRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*apiClient)
 
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	// Read the current configuration to get managed groups
 	ruleGroups, err := parseRuleGroupsConfiguration(d)
@@ -512,8 +512,8 @@ func resourcelokiRulesRead(ctx context.Context, d *schema.ResourceData, m interf
 func resourcelokiRulesUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*apiClient)
 
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	// Get new configuration
 	newRuleGroups, err := parseRuleGroupsConfiguration(d)
@@ -561,8 +561,8 @@ func resourcelokiRulesUpdate(ctx context.Context, d *schema.ResourceData, m inte
 func resourcelokiRulesDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	client := m.(*apiClient)
 
-	namespace := d.Get("namespace").(string)
-	orgID := d.Get("org_id").(string)
+	namespace := d.Get(namespaceKey).(string)
+	orgID := d.Get(orgIDKey).(string)
 
 	// Get list of managed groups from state
 	managedGroupsInterface := d.Get("managed_groups").([]interface{})
@@ -593,8 +593,8 @@ func resourcelokiRulesImport(ctx context.Context, d *schema.ResourceData, m inte
 
 	if len(parts) == 2 {
 		// Multi-tenant: orgID/namespace
-		d.Set("org_id", parts[0])
-		d.Set("namespace", parts[1])
+		d.Set(orgIDKey, parts[0])
+		d.Set(namespaceKey, parts[1])
 	} else {
 		return nil, fmt.Errorf("import ID must be in format: namespace or orgID/namespace")
 	}
@@ -699,7 +699,7 @@ func setComputedFields(d *schema.ResourceData, ruleGroups RuleGroups, managedGro
 
 		groupDetail := map[string]interface{}{
 			"name":                  group.Name,
-			"interval":              group.Interval,
+			intervalKey:             group.Interval,
 			"rules_count":           len(group.Rules),
 			"alerting_rules_count":  alertingCount,
 			"recording_rules_count": recordingCount,


### PR DESCRIPTION
`golangci-lint run ./...` currently reports 17 issues on `main`, which fails the `Build` job on every pull request. The CI action pins `version: latest`, so the failures appeared through linter drift rather than through any code change.

- **15 × `goconst`** — the schema attribute names `org_id`, `namespace`, `interval`, `labels` and the shared `org_id` description each cross the 5-occurrence threshold. Extracted into a new `loki/constants.go` (`orgIDKey`, `orgIDDescription`, `namespaceKey`, `intervalKey`, `labelsKey`), mirroring the naming already used in `mimir/constants.go` in the sibling provider.
- **2 × `gosec` G706** (log injection) — `api_client_test.go` logs two request headers taken straight from the incoming request. Wrapped in `strconv.Quote`, which gosec's taint analysis accepts as a sanitizer, so the values are escaped instead of the rule being excluded.

No behaviour change: the literals are replaced by constants holding exactly the same values, and the two `gosec` findings are in test-only debug logging.

`golangci-lint run ./...` now reports 0 issues; `go build ./...`, `go vet ./...` and the unit tests pass.