### PR TITLE
ci: pin tool versions and make docs generation real

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,28 +22,29 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
-      -
-        name: Unshallow
-        run: git fetch --prune --unshallow
+        uses: actions/checkout@v7
+        with:
+          # goreleaser needs the full history to build the changelog
+          fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v7
         with:
           go-version-file: 'go.mod'
           cache: true
       -
         name: Import GPG key
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v7
         id: import_gpg
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.1.0
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          # .goreleaser.yml is schema version 2, so stay on the goreleaser v2 line
+          version: '~> v2'
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,26 +14,29 @@ on:
       - 'CHANGELOG.md'
       - 'website/*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v7
       with:
-        go-version: '1.23'
+        go-version-file: 'go.mod'
       id: go
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-
     - name: Run linters
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v9
       with:
-        version: latest
+        version: v2.13.1
 
     - name: Generate
       run: make generate
@@ -47,7 +50,7 @@ jobs:
       run: make build
 
   test:
-    name: 'Acc. Tests (OS: ${{ matrix.os }} / TF: ${{ matrix.terraform }})'
+    name: 'Acc. Tests (Loki ${{ matrix.loki-version }} / TF ${{ matrix.terraform }} / ${{ matrix.os }})'
     needs: build
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -57,24 +60,31 @@ jobs:
         os:
           - ubuntu-latest
         terraform:
-          - '1.5.*'
+          - '1.5.7'
+        # 3.6.x and 3.7.x are the only actively patched lines; 2.9.17 is kept as
+        # a best-effort check on the last 2.x release.
         loki-version:
-          - '2.9.14'
-          - '3.4.6'
-          - '3.5.5'
+          - '2.9.17'
+          - '3.5.12'
+          - '3.6.15'
+          - '3.7.6'
+        # Guard against Terraform-side regressions without multiplying the matrix.
+        include:
+          - os: ubuntu-latest
+            terraform: '1.15.9'
+            loki-version: '3.7.6'
     steps:
 
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.23'
-        check-latest: true
-
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
+
+    - name: Setup Go
+      uses: actions/setup-go@v7
+      with:
+        go-version-file: 'go.mod'
 
     - name: Setup Terraform ${{ matrix.terraform }}
-      uses: hashicorp/setup-terraform@v2
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_version: ${{ matrix.terraform }}
         terraform_wrapper: false
@@ -89,4 +99,4 @@ jobs:
 
     - name: Dump docker logs on failure
       if: failure()
-      uses: jwalton/gh-docker-logs@v2
+      uses: jwalton/gh-docker-logs@v2.2.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,11 @@ jobs:
         version: v2.13.1
 
     - name: Generate
+      # setup-go pins GOTOOLCHAIN=local, but tfplugindocs needs a newer Go than
+      # the one go.mod declares. Let this one step fetch the toolchain it asks
+      # for instead of raising the module's own Go version.
+      env:
+        GOTOOLCHAIN: auto
       run: make generate
 
     - name: Confirm no diff

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-LOKI_VERSION ?= 2.8.3
+LOKI_VERSION ?= 3.7.6
 
 default: build
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,12 +12,9 @@ services:
       - ./config.yaml:/etc/loki/config.yaml
     command:
       - --config.file=/etc/loki/config.yaml
-    healthcheck:
-      test: ["CMD", "wget", "-O-", "http://localhost:3100/ready"]
-      timeout: 45s
-      interval: 30s
-      start_period: 40s
-      retries: 3
+    # No healthcheck: busybox (and so wget/sh) was removed from the official Loki
+    # images in 3.5.8, and the image ships no other probe tool. The Makefile polls
+    # /ready from the host instead.
   s3:
     image: minio/minio
     container_name: minio

--- a/docs/data-sources/rule_group_alerting.md
+++ b/docs/data-sources/rule_group_alerting.md
@@ -47,5 +47,3 @@ Read-Only:
 - `expr` (String)
 - `for` (String)
 - `labels` (Map of String)
-
-

--- a/docs/data-sources/rule_group_list.md
+++ b/docs/data-sources/rule_group_list.md
@@ -53,5 +53,3 @@ Read-Only:
 - `for` (String)
 - `labels` (Map of String)
 - `record` (String)
-
-

--- a/docs/data-sources/rule_group_recording.md
+++ b/docs/data-sources/rule_group_recording.md
@@ -45,5 +45,3 @@ Read-Only:
 - `expr` (String)
 - `labels` (Map of String)
 - `record` (String)
-
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -64,8 +64,8 @@ provider "loki" {
   org_id = "mytenant"
 
   aws_sigv4 {
-    region  = "us-east-1"       # Optional, defaults to AWS_REGION env var
-    service = "execute-api"     # Optional, defaults to "execute-api"
+    region  = "us-east-1"   # Optional, defaults to AWS_REGION env var
+    service = "execute-api" # Optional, defaults to "execute-api"
   }
 }
 ```
@@ -86,7 +86,7 @@ AWS credentials are loaded from the default credential chain:
 
 ### Optional
 
-- `aws_sigv4` (Block List, Max: 1) AWS Signature Version 4 authentication configuration. When configured, requests will be signed using AWS credentials from the default credential chain. (see [below for nested schema](#nestedblock--aws_sigv4))
+- `aws_sigv4` (Block List, Max: 1) AWS Signature Version 4 authentication configuration. When configured, requests will be signed using AWS credentials from the default credential chain (environment variables, shared credentials file, IAM role, etc.). (see [below for nested schema](#nestedblock--aws_sigv4))
 - `ca` (String) Client ca for client authentication
 - `cert` (String) Client cert for client authentication
 - `debug` (Boolean) Enable debug mode to trace requests executed.

--- a/docs/resources/rule_group_alerting.md
+++ b/docs/resources/rule_group_alerting.md
@@ -73,6 +73,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import loki_rule_group_alerting.test {{namespace/name}}
 ```

--- a/docs/resources/rule_group_recording.md
+++ b/docs/resources/rule_group_recording.md
@@ -62,6 +62,8 @@ Optional:
 
 Import is supported using the following syntax:
 
+The [`terraform import` command](https://developer.hashicorp.com/terraform/cli/commands/import) can be used, for example:
+
 ```shell
 terraform import loki_rule_group_recording.test {{namespace/name}}
 ```

--- a/docs/resources/rules.md
+++ b/docs/resources/rules.md
@@ -4,9 +4,9 @@ page_title: "loki_rules Resource - terraform-provider-loki"
 subcategory: ""
 description: |-
   Manages multiple Loki rule groups within a namespace.
-          This resource is designed to handle YAML files containing multiple rule groups.
-          Each rule group is managed individually via the Loki API, but they are tracked
-          together as a single Terraform resource for easier bulk management.
+  This resource is designed to handle YAML files containing multiple rule groups.
+  Each rule group is managed individually via the Loki API, but they are tracked
+  together as a single Terraform resource for easier bulk management.
 ---
 
 # loki_rules (Resource)
@@ -173,5 +173,3 @@ Read-Only:
 - `name` (String)
 - `recording_rules_count` (Number)
 - `rules_count` (Number)
-
-

--- a/examples/provider/provider-aws-sigv4.tf
+++ b/examples/provider/provider-aws-sigv4.tf
@@ -1,0 +1,9 @@
+provider "loki" {
+  uri    = "https://private-alb.example.com"
+  org_id = "mytenant"
+
+  aws_sigv4 {
+    region  = "us-east-1"   # Optional, defaults to AWS_REGION env var
+    service = "execute-api" # Optional, defaults to "execute-api"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.28.6
 	github.com/grafana/loki/v3 v3.4.2
 	github.com/hashicorp/go-version v1.6.0
-	github.com/hashicorp/terraform-plugin-docs v0.15.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/prometheus/common v0.61.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -24,7 +23,6 @@ require (
 	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
-	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.47 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.26 // indirect
@@ -37,7 +35,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.2 // indirect
 	github.com/aws/smithy-go v1.22.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bgentry/speakeasy v0.1.0 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.3.3 // indirect
@@ -107,7 +104,6 @@ require (
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mdlayher/vsock v1.2.1 // indirect
 	github.com/miekg/dns v1.1.62 // indirect
-	github.com/mitchellh/cli v1.1.5 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
@@ -125,14 +121,12 @@ require (
 	github.com/pires/go-proxyproto v0.7.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/posener/complete v1.2.3 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/exporter-toolkit v0.13.2 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/prometheus/prometheus v0.55.0 // indirect
 	github.com/redis/go-redis/v9 v9.7.0 // indirect
-	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 // indirect
 	github.com/sercand/kuberesolver/v5 v5.1.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,8 @@ github.com/HdrHistogram/hdrhistogram-go v1.1.2 h1:5IcZpTvzydCQeHzK4Ef/D5rrSqwxob
 github.com/HdrHistogram/hdrhistogram-go v1.1.2/go.mod h1:yDgFjdqOqDEKOvasDdhWNXYg9BVp4O+o5f6V/ehm6Oo=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
 github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
-github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
@@ -63,7 +61,6 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-metrics v0.4.1 h1:hR91U9KYmb6bLBYLQjyM+3j+rcd/UhE+G78SFnF8gJA=
 github.com/armon/go-metrics v0.4.1/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
@@ -99,7 +96,6 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
 github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
@@ -245,7 +241,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
-github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -333,8 +328,6 @@ github.com/hashicorp/terraform-exec v0.18.1 h1:LAbfDvNQU1l0NOQlTuudjczVhHj061fNX
 github.com/hashicorp/terraform-exec v0.18.1/go.mod h1:58wg4IeuAJ6LVsLUeD2DWZZoc/bYi6dzhLHzxM41980=
 github.com/hashicorp/terraform-json v0.17.0 h1:EiA1Wp07nknYQAiv+jIt4dX4Cq5crgP+TsTE45MjMmM=
 github.com/hashicorp/terraform-json v0.17.0/go.mod h1:Huy6zt6euxaY9knPAFKjUITn8QxUFIe9VuSzb4zn/0o=
-github.com/hashicorp/terraform-plugin-docs v0.15.0 h1:W5xYB5kCUBqO7lyjE2UMmUBh95c0aAf4jwO0Xuuw2Ec=
-github.com/hashicorp/terraform-plugin-docs v0.15.0/go.mod h1:K5Taof1Y7sL4dw6Ie0qMFyQnHN0W+RSVMD0iIyFDFJc=
 github.com/hashicorp/terraform-plugin-go v0.16.0 h1:DSOQ0rz5FUiVO4NUzMs8ln9gsPgHMTsfns7Nk+6gPuE=
 github.com/hashicorp/terraform-plugin-go v0.16.0/go.mod h1:4sn8bFuDbt+2+Yztt35IbOrvZc0zyEi87gJzsTgCES8=
 github.com/hashicorp/terraform-plugin-log v0.9.0 h1:i7hOA+vdAItN1/7UrfBqBwvYPQ9TFvymaRGZED3FCV0=
@@ -347,11 +340,8 @@ github.com/hashicorp/terraform-svchost v0.1.1 h1:EZZimZ1GxdqFRinZ1tpJwVxxt49xc/S
 github.com/hashicorp/terraform-svchost v0.1.1/go.mod h1:mNsjQfZyf/Jhz35v6/0LWcv26+X7JPS+buii2c9/ctc=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
-github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
@@ -414,9 +404,6 @@ github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJys
 github.com/miekg/dns v1.1.62 h1:cN8OuEF1/x5Rq6Np+h1epln8OiyPWV+lROx9LxcGgIQ=
 github.com/miekg/dns v1.1.62/go.mod h1:mvDlcItzm+br7MToIKqkglaGhlFMHJ9DTNNWONWXbNQ=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
-github.com/mitchellh/cli v1.1.5 h1:OxRIeJXpAMztws/XHlN2vu6imG5Dpq+j61AzAX5fLng=
-github.com/mitchellh/cli v1.1.5/go.mod h1:v8+iFts2sPIKUV1ltktPXMCC8fumSKFItNcD2cLtRR4=
-github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
@@ -428,7 +415,6 @@ github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTS
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4 h1:BpfhmLKZf+SjVanKKhCgf3bg+511DmU9eDQTen7LLbY=
 github.com/mitchellh/mapstructure v1.5.1-0.20220423185008-bf980b35cac4/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
-github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -474,7 +460,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/posener/complete v1.2.3 h1:NP0eAhjcjImqslEwo/1hq7gpajME0fTLTezBKDqfXqo=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -515,8 +500,6 @@ github.com/redis/rueidis v1.0.19/go.mod h1:8B+r5wdnjwK3lTFml5VtxjzGOQAC+5UmujoD1
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
-github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
-github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -524,7 +507,6 @@ github.com/sercand/kuberesolver/v5 v5.1.1 h1:CYH+d67G0sGBj7q5wLK61yzqJJ8gLLC8aep
 github.com/sercand/kuberesolver/v5 v5.1.1/go.mod h1:Fs1KbKhVRnB2aDWN12NjKCB+RgYMWZJ294T3BtmVCpQ=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -534,7 +516,6 @@ github.com/skeema/knownhosts v1.1.0 h1:Wvr9V0MxhjRbl3f9nMnKnFfiWTJmtECJ9Njkea3ys
 github.com/skeema/knownhosts v1.1.0/go.mod h1:sKFq3RD6/TKZkSWn8boUbDC7Qkgcv+8XXijpFO6roag=
 github.com/sony/gobreaker/v2 v2.1.0 h1:av2BnjtRmVPWBvy5gSFPytm1J8BmN5AGhq875FfGKDM=
 github.com/sony/gobreaker/v2 v2.1.0/go.mod h1:dO3Q/nCzxZj6ICjH6J/gM0r4oAwBMVLY8YAQf+NTtUg=
-github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=
 github.com/spf13/cast v1.7.0/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -619,9 +600,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190923035154-9ee001bba392/go.mod h1:/lpIB1dKB+9EgE3H3cr1v9wB50oz8l4C4h62xy7jSTY=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20200414173820-0848c9571904/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
 golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=

--- a/main.go
+++ b/main.go
@@ -1,5 +1,9 @@
 package main
 
+// Keep the tfplugindocs version pinned: the generated markdown differs between
+// versions, and the CI "Confirm no diff" step compares against what is committed.
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs@v0.25.0 generate --provider-name terraform-provider-loki
+
 import (
 	"flag"
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -28,4 +28,16 @@ The Loki provider provides configuration management resources for
 
 {{ tffile "examples/provider/provider-custom-headers.tf" }}
 
+### Creating a Loki provider with AWS SigV4 authentication
+
+Use this configuration when connecting to Loki through AWS API Gateway with IAM authentication.
+
+{{ tffile "examples/provider/provider-aws-sigv4.tf" }}
+
+AWS credentials are loaded from the default credential chain:
+1. Environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`)
+2. Shared credentials file (`~/.aws/credentials`)
+3. IAM role (EC2, ECS, Lambda)
+4. Web identity token (EKS IRSA)
+
 {{ .SchemaMarkdown | trimspace }}

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-
-package tools
-
-import (
-	// document generation
-	_ "github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs"
-)


### PR DESCRIPTION
Three related problems in the CI setup.

### Unpinned tool versions

`golangci-lint` was installed with `version: latest`, which is how a linter bump turned every pull request red without a single line of code changing. It is now pinned to `v2.13.1` — the version that has just been verified green on `main`. Similarly, the release workflow ran goreleaser at `version: latest` while `.goreleaser.yml` declares `version: 2`, so it worked only by coincidence and would break the day goreleaser v3 ships; it now tracks `~> v2`.

Actions are bumped to current majors (`checkout@v7`, `setup-go@v7`, `setup-terraform@v4`, `golangci-lint-action@v9`, `ghaction-import-gpg@v7`), each checked against its `action.yml` to confirm the inputs in use are still supported. The Go version now comes from `go.mod` instead of a hardcoded `1.23`, so there is one source of truth. A `permissions: contents: read` block is added to the test workflow.

### The acceptance matrix did not report which Loki it ran

All three matrix jobs published the same check name, since the job name interpolated only `os` and `terraform`. It now reads `Acc. Tests (Loki 3.7.6 / TF 1.5.7 / ubuntu-latest)`.

The Loki versions themselves were stale on every axis: 3.4.6 ended its line, 3.5.5 is several patches behind, and neither of the two actively patched lines was tested at all. The matrix is now `2.9.17`, `3.5.12`, `3.6.15`, `3.7.6`, with a single additional job pinning a recent Terraform against the newest Loki rather than multiplying the matrix. `LOKI_VERSION` in the Makefile defaulted to `2.8.3` and now matches the newest tested version.

The docker-compose healthcheck used `wget`, which no longer exists in the official images: busybox was removed in Loki 3.5.8. Nothing depends on the container's health today so it was invisible, but it would have shown up as a permanently unhealthy container once the matrix moved past 3.5.8. The Makefile already polls `/ready` from the host, so the healthcheck is dropped.

### `make generate` generated nothing

There is no `//go:generate` directive anywhere in the repository, so the target was a no-op and the `Confirm no diff` step that follows it had never verified anything. Two things fell out of fixing it:

- The pinned `tfplugindocs` v0.15.0 no longer runs at all — it fails with `openpgp: key expired` while verifying Terraform checksums. It is now invoked as `go run ...@v0.25.0`, which keeps the module at its current Go version instead of forcing the toolchain up.
- The AWS SigV4 section of `docs/index.md` had been written by hand into a generated file. It is absent from `templates/index.md.tmpl`, so the first successful regeneration would have deleted it. It is moved into the template with a matching example under `examples/provider/`, and the `aws_sigv4` description in the docs had already drifted from the schema.

`tools/tools.go` is removed since the tool is no longer a module dependency. Docs regenerate idempotently, lint reports 0 issues, and the build and unit tests pass.