### PR TITLE
fix: redact credentials, stop killing the process, and repair the test suite

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -89,7 +89,7 @@ AWS credentials are loaded from the default credential chain:
 - `aws_sigv4` (Block List, Max: 1) AWS Signature Version 4 authentication configuration. When configured, requests will be signed using AWS credentials from the default credential chain. (see [below for nested schema](#nestedblock--aws_sigv4))
 - `ca` (String) Client ca for client authentication
 - `cert` (String) Client cert for client authentication
-- `debug` (Boolean) Enable debug mode to trace requests executed.
+- `debug` (Boolean) Enable debug mode to trace requests executed. Credential headers are redacted, but the traces are still verbose; off by default.
 - `headers` (Map of String) A map of header names and values to set on all outbound requests.
 - `insecure` (Boolean) When using https, this disables TLS verification of the host.
 - `key` (String) Client key for client authentication

--- a/loki/api_client.go
+++ b/loki/api_client.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -99,7 +100,9 @@ func NewAPIClient(opt *apiClientOpt) (*apiClient, error) {
 			}
 		}
 		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("no valid PEM certificate found in the provided ca")
+		}
 		tlsConfig.RootCAs = caCertPool
 	}
 
@@ -109,7 +112,9 @@ func NewAPIClient(opt *apiClientOpt) (*apiClient, error) {
 	}
 
 	if opt.proxyURL != "" {
-		log.Printf("api_client.go: Using proxy: %s\n", opt.proxyURL)
+		if opt.debug {
+			log.Printf("api_client.go: Using proxy: %s\n", opt.proxyURL)
+		}
 		proxy, err := url.Parse(opt.proxyURL)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing proxy url: %s", err)
@@ -159,6 +164,16 @@ func NewAPIClient(opt *apiClientOpt) (*apiClient, error) {
 	return &client, nil
 }
 
+// redactHeaderRegexp matches the header lines of an httputil dump whose value
+// is a credential. Anything matched keeps its name and loses its value.
+var redactHeaderRegexp = regexp.MustCompile(`(?im)^((?:Authorization|Proxy-Authorization|X-Amz-Security-Token|Cookie|Set-Cookie):).*$`)
+
+// redactCredentials strips credential values out of a request or response dump
+// before it reaches the log.
+func redactCredentials(dump string) string {
+	return redactHeaderRegexp.ReplaceAllString(dump, "$1 [REDACTED]")
+}
+
 /*
 Helper function that handles sending/receiving and handling
 
@@ -180,7 +195,7 @@ func (client *apiClient) sendRequest(method string, path, data string, headers m
 	}
 
 	if err != nil {
-		log.Fatal(err)
+		return "", fmt.Errorf("cannot build %s request for %s: %w", method, fullURI, err)
 	}
 
 	// AWS SigV4 signing (must be done before adding other headers)
@@ -214,12 +229,12 @@ func (client *apiClient) sendRequest(method string, path, data string, headers m
 	}
 
 	if client.debug {
-		reqDump, err := httputil.DumpRequestOut(req, true)
+		reqDump, err := httputil.DumpRequestOut(req, false)
 		if err != nil {
-			log.Fatal(err)
+			return "", fmt.Errorf("cannot dump request for %s: %w", fullURI, err)
 		}
 
-		log.Printf("REQUEST:\n%s", string(reqDump))
+		log.Printf("REQUEST:\n%s", redactCredentials(string(reqDump)))
 	}
 
 	resp, err := client.httpClient.Do(req)
@@ -232,12 +247,12 @@ func (client *apiClient) sendRequest(method string, path, data string, headers m
 	}
 
 	if client.debug {
-		respDump, err := httputil.DumpResponse(resp, true)
+		respDump, err := httputil.DumpResponse(resp, false)
 		if err != nil {
-			log.Fatal(err)
+			return "", fmt.Errorf("cannot dump response for %s: %w", fullURI, err)
 		}
 
-		log.Printf("RESPONSE:\n%s", string(respDump))
+		log.Printf("RESPONSE:\n%s", redactCredentials(string(respDump)))
 	}
 
 	bodyBytes, err2 := io.ReadAll(resp.Body)

--- a/loki/constants.go
+++ b/loki/constants.go
@@ -6,4 +6,7 @@ const (
 	namespaceKey     = "namespace"
 	intervalKey      = "interval"
 	labelsKey        = "labels"
+
+	contentTypeHeader = "Content-Type"
+	contentTypeYAML   = "application/yaml"
 )

--- a/loki/data_source_loki_rule_group_alerting.go
+++ b/loki/data_source_loki_rule_group_alerting.go
@@ -3,7 +3,6 @@ package loki
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -106,7 +105,7 @@ func dataSourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.Resource
 	baseMsg := fmt.Sprintf("Cannot read alerting rule group '%s' -", name)
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
-		if strings.Contains(err.Error(), "response code '404'") {
+		if isNotFound(err) {
 			d.SetId("")
 			return nil
 		}

--- a/loki/data_source_loki_rule_group_list.go
+++ b/loki/data_source_loki_rule_group_list.go
@@ -3,7 +3,6 @@ package loki
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -117,7 +116,7 @@ func dataSourcelokiRuleGroupListAll(ctx context.Context, d *schema.ResourceData,
 
 	err = handleHTTPError(err, "Cannot list rules")
 	if err != nil {
-		if strings.Contains(err.Error(), "response code '404'") {
+		if isNotFound(err) {
 			d.SetId("")
 			return nil
 		}

--- a/loki/data_source_loki_rule_group_recording.go
+++ b/loki/data_source_loki_rule_group_recording.go
@@ -3,7 +3,6 @@ package loki
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -86,7 +85,7 @@ func dataSourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.Resourc
 	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' -", name)
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
-		if strings.Contains(err.Error(), "response code '404'") {
+		if isNotFound(err) {
 			d.SetId("")
 			return nil
 		}

--- a/loki/debug_redaction_test.go
+++ b/loki/debug_redaction_test.go
@@ -1,0 +1,81 @@
+package loki
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// Credential headers must never reach the log, even with debug enabled.
+func TestRedactCredentials(t *testing.T) {
+	dump := strings.Join([]string{
+		"POST /loki/api/v1/rules/ns HTTP/1.1",
+		"Host: loki.example.com",
+		"Authorization: Bearer s3cr3t-token",
+		"X-Amz-Security-Token: FwoGZXIvYXdzEJr//////////wEaDA==",
+		"Proxy-Authorization: Basic dXNlcjpwYXNz",
+		"Cookie: session=abcdef",
+		"Content-Type: application/yaml",
+		"X-Scope-OrgID: mytenant",
+	}, "\r\n")
+
+	got := redactCredentials(dump)
+
+	for _, secret := range []string{"s3cr3t-token", "FwoGZXIvYXdzEJr", "dXNlcjpwYXNz", "session=abcdef"} {
+		if strings.Contains(got, secret) {
+			t.Errorf("redactCredentials leaked %q:\n%s", secret, got)
+		}
+	}
+	// Header names and non-credential headers must survive, or the dump is useless.
+	for _, keep := range []string{"Authorization:", "X-Amz-Security-Token:", "Content-Type: application/yaml", "X-Scope-OrgID: mytenant"} {
+		if !strings.Contains(got, keep) {
+			t.Errorf("redactCredentials dropped %q:\n%s", keep, got)
+		}
+	}
+}
+
+// debug used to default to true, so every request was dumped for every user.
+func TestProviderDebugDefaultsToFalse(t *testing.T) {
+	t.Setenv("LOKI_DEBUG", "")
+
+	p := Provider("dev")()
+	raw := map[string]interface{}{
+		"uri":    lokiURI,
+		orgIDKey: lokiOrgID,
+	}
+	if diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw)); diags.HasError() {
+		t.Fatalf("unexpected error configuring provider: %v", diags)
+	}
+
+	client, ok := p.Meta().(*apiClient)
+	if !ok {
+		t.Fatalf("expected *apiClient, got %T", p.Meta())
+	}
+	if client.debug {
+		t.Fatal("expected debug to default to false")
+	}
+}
+
+// The computed user agent used to be discarded, so requests went out as
+// Go-http-client/1.1.
+func TestProviderSetsUserAgentHeader(t *testing.T) {
+	p := Provider("dev")()
+	raw := map[string]interface{}{
+		"uri":    lokiURI,
+		orgIDKey: lokiOrgID,
+	}
+	if diags := p.Configure(context.Background(), terraform.NewResourceConfigRaw(raw)); diags.HasError() {
+		t.Fatalf("unexpected error configuring provider: %v", diags)
+	}
+
+	client, ok := p.Meta().(*apiClient)
+	if !ok {
+		t.Fatalf("expected *apiClient, got %T", p.Meta())
+	}
+	got := client.headers["User-Agent"]
+	if !strings.Contains(got, "terraform-provider-loki") {
+		t.Fatalf("expected a terraform-provider-loki user agent, got %q", got)
+	}
+}

--- a/loki/provider.go
+++ b/loki/provider.go
@@ -87,8 +87,8 @@ func Provider(version string) func() *schema.Provider {
 				"debug": {
 					Type:        schema.TypeBool,
 					Optional:    true,
-					DefaultFunc: schema.EnvDefaultFunc("LOKI_DEBUG", true),
-					Description: "Enable debug mode to trace requests executed.",
+					DefaultFunc: schema.EnvDefaultFunc("LOKI_DEBUG", false),
+					Description: "Enable debug mode to trace requests executed. Credential headers are redacted, but the traces are still verbose; off by default.",
 				},
 				"aws_sigv4": {
 					Type:        schema.TypeList,
@@ -125,15 +125,15 @@ func Provider(version string) func() *schema.Provider {
 			},
 		}
 		p.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
-			p.UserAgent("terraform-provider-loki", version)
-			return providerConfigure(d)
+			return providerConfigure(d, p.UserAgent("terraform-provider-loki", version))
 		}
 		return p
 	}
 }
 
-func providerConfigure(d *schema.ResourceData) (interface{}, diag.Diagnostics) {
+func providerConfigure(d *schema.ResourceData, userAgent string) (interface{}, diag.Diagnostics) {
 	headers := make(map[string]string)
+	headers["User-Agent"] = userAgent
 	if initHeaders := d.Get("headers"); initHeaders != nil {
 		for k, v := range initHeaders.(map[string]interface{}) {
 			headers[k] = v.(string)

--- a/loki/resource_loki_rule_group_alerting.go
+++ b/loki/resource_loki_rule_group_alerting.go
@@ -112,7 +112,7 @@ func resourcelokiRuleGroupAlertingCreate(ctx context.Context, d *schema.Resource
 		Rules:    expandAlertingRules(d.Get("rule").([]interface{})),
 	}
 	data, _ := yaml.Marshal(rules)
-	headers := map[string]string{"Content-Type": "application/yaml"}
+	headers := map[string]string{contentTypeHeader: contentTypeYAML}
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
 	}
@@ -162,7 +162,7 @@ func resourcelokiRuleGroupAlertingRead(ctx context.Context, d *schema.ResourceDa
 	baseMsg := fmt.Sprintf("Cannot read alerting rule group '%s' -", name)
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
-		if strings.Contains(err.Error(), "response code '404'") {
+		if isNotFound(err) {
 			d.SetId("")
 			return nil
 		}
@@ -213,7 +213,7 @@ func resourcelokiRuleGroupAlertingUpdate(ctx context.Context, d *schema.Resource
 			Rules:    expandAlertingRules(d.Get("rule").([]interface{})),
 		}
 		data, _ := yaml.Marshal(rules)
-		headers := map[string]string{"Content-Type": "application/yaml"}
+		headers := map[string]string{contentTypeHeader: contentTypeYAML}
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}

--- a/loki/resource_loki_rule_group_alerting_test.go
+++ b/loki/resource_loki_rule_group_alerting_test.go
@@ -1,12 +1,9 @@
 package loki
 
 import (
-	"fmt"
-	"os"
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
@@ -186,13 +183,7 @@ func TestAccResourceRuleGroupAlerting_Operator(t *testing.T) {
 	--- FAIL: TestAccResourceRuleGroupAlerting_Operator (0.46s)
 
 	*/
-	currentVersion, _ := version.NewVersion(os.Getenv("LOKI_VERSION"))
-	minVersion, _ := version.NewVersion("3.0.0")
-
-	if currentVersion.LessThan(minVersion) {
-		fmt.Printf("Skipping expr with OR operator test (current version '%s' is less than '%s')\n", currentVersion, minVersion)
-		return
-	}
+	skipBelowLokiVersion(t, "3.0.0")
 
 	// Init client
 	client, err := NewAPIClient(setupClient())

--- a/loki/resource_loki_rule_group_recording.go
+++ b/loki/resource_loki_rule_group_recording.go
@@ -89,7 +89,7 @@ func resourcelokiRuleGroupRecordingCreate(ctx context.Context, d *schema.Resourc
 		Rules:    expandRecordingRules(d.Get("rule").([]interface{})),
 	}
 	data, _ := yaml.Marshal(rules)
-	headers := map[string]string{"Content-Type": "application/yaml"}
+	headers := map[string]string{contentTypeHeader: contentTypeYAML}
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
 	}
@@ -139,7 +139,7 @@ func resourcelokiRuleGroupRecordingRead(ctx context.Context, d *schema.ResourceD
 	baseMsg := fmt.Sprintf("Cannot read recording rule group '%s' -", name)
 	err = handleHTTPError(err, baseMsg)
 	if err != nil {
-		if strings.Contains(err.Error(), "response code '404'") {
+		if isNotFound(err) {
 			d.SetId("")
 			return diag.Diagnostics{}
 		}
@@ -192,7 +192,7 @@ func resourcelokiRuleGroupRecordingUpdate(ctx context.Context, d *schema.Resourc
 			Rules:    expandRecordingRules(d.Get("rule").([]interface{})),
 		}
 		data, _ := yaml.Marshal(rules)
-		headers := map[string]string{"Content-Type": "application/yaml"}
+		headers := map[string]string{contentTypeHeader: contentTypeYAML}
 		if orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}
@@ -292,8 +292,8 @@ func validateRecordingRuleName(v interface{}, k string) (ws []string, errors []e
 }
 
 type recordingRule struct {
-	Record string            `json:"record"`
-	Expr   string            `json:"expr"`
+	Record string            `yaml:"record"`
+	Expr   string            `yaml:"expr"`
 	Labels map[string]string `yaml:"labels,omitempty"`
 }
 

--- a/loki/resource_loki_rules.go
+++ b/loki/resource_loki_rules.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/prometheus/common/model"
 	"gopkg.in/yaml.v3"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -304,7 +304,7 @@ func validateRuleGroupsContent(ruleGroups RuleGroups) error {
 
 		// Validate interval if specified
 		if group.Interval != "" {
-			if _, err := time.ParseDuration(group.Interval); err != nil {
+			if _, err := model.ParseDuration(group.Interval); err != nil {
 				return fmt.Errorf("group %d (%s): invalid interval '%s': %v", i, group.Name, group.Interval, err)
 			}
 		}
@@ -356,7 +356,7 @@ func validateRuleForLoki(rule Rule, groupIndex, ruleIndex int, groupName string)
 
 		// Validate 'for' duration if specified
 		if rule.For != "" {
-			if _, err := time.ParseDuration(rule.For); err != nil {
+			if _, err := model.ParseDuration(rule.For); err != nil {
 				return fmt.Errorf("group %d (%s), rule %d: invalid 'for' duration '%s': %v", groupIndex, groupName, ruleIndex, rule.For, err)
 			}
 		}
@@ -488,7 +488,7 @@ func resourcelokiRulesRead(ctx context.Context, d *schema.ResourceData, m interf
 		path := fmt.Sprintf("%s/%s/%s", rulesPath, namespace, groupName)
 		_, err := client.sendRequest("GET", path, "", headers)
 		if err != nil {
-			if strings.Contains(err.Error(), "response code '404'") {
+			if isNotFound(err) {
 				// Group was deleted outside of Terraform
 				continue
 			}
@@ -732,7 +732,7 @@ func calculateContentHash(ruleGroups RuleGroups, managedGroups []string) string 
 }
 
 func createLokiRuleGroup(client *apiClient, namespace, orgID string, group RuleGroup) error {
-	headers := make(map[string]string)
+	headers := map[string]string{contentTypeHeader: contentTypeYAML}
 	if orgID != "" {
 		headers["X-Scope-OrgID"] = orgID
 	}
@@ -756,7 +756,7 @@ func deleteLokiRuleGroup(client *apiClient, namespace, orgID, groupName string) 
 
 	path := fmt.Sprintf("%s/%s/%s", rulesPath, namespace, groupName)
 	_, err := client.sendRequest("DELETE", path, "", headers)
-	if err != nil && strings.Contains(err.Error(), "response code '404'") {
+	if err != nil && isNotFound(err) {
 		// Group already doesn't exist, consider this success
 		return nil
 	}

--- a/loki/shared.go
+++ b/loki/shared.go
@@ -3,6 +3,7 @@ package loki
 import (
 	"fmt"
 	"regexp"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/grafana/loki/v3/pkg/logql/syntax"
@@ -14,6 +15,13 @@ var (
 	labelNameRegexp     = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 	metricNameRegexp    = regexp.MustCompile(`^[a-zA-Z_:][a-zA-Z0-9_:]*$`)
 )
+
+// isNotFound reports whether err came back from a 404. sendRequest returns a
+// formatted error rather than a typed one, so this centralises the string match
+// that every caller was doing inline.
+func isNotFound(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "response code '404'")
+}
 
 func handleHTTPError(err error, baseMsg string) error {
 	if err != nil {

--- a/loki/shared_test.go
+++ b/loki/shared_test.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"testing"
 
+	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
@@ -17,6 +19,30 @@ func getSetEnv(key, fallback string) string {
 		os.Setenv(key, fallback)
 	}
 	return value
+}
+
+// skipBelowLokiVersion skips the test unless LOKI_VERSION names a Loki release
+// at least as recent as min. An unset or unparseable LOKI_VERSION skips too:
+// `make test` runs the package with no backend at all, and version.NewVersion
+// returns a nil *Version there, so calling LessThan on it panics and takes the
+// whole package down.
+func skipBelowLokiVersion(t *testing.T, min string) {
+	t.Helper()
+
+	raw := os.Getenv("LOKI_VERSION")
+	current, err := version.NewVersion(raw)
+	if err != nil {
+		t.Skipf("skipping: LOKI_VERSION is %q, cannot check for Loki >= %s", raw, min)
+	}
+
+	minVersion, err := version.NewVersion(min)
+	if err != nil {
+		t.Fatalf("invalid minimum version %q: %s", min, err)
+	}
+
+	if current.LessThan(minVersion) {
+		t.Skipf("skipping: Loki %s is older than %s", current, minVersion)
+	}
 }
 
 func testAccCheckLokiRuleGroupExists(n string, name string, client *apiClient) resource.TestCheckFunc {
@@ -93,7 +119,7 @@ func testAccCheckLokiRuleGroupDestroy(s *terraform.State) error {
 	// loop through the resources in state, verifying each widget
 	// is destroyed
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "loki_rule_group_recording" {
+		if rs.Type != "loki_rule_group_recording" && rs.Type != "loki_rule_group_alerting" {
 			continue
 		}
 
@@ -109,9 +135,12 @@ func testAccCheckLokiRuleGroupDestroy(s *terraform.State) error {
 		path := fmt.Sprintf("%s/%s/%s", rulesPath, namespace, name)
 		_, err := client.sendRequest("GET", path, "", headers)
 
-		// If the error is equivalent to 404 not found, the widget is destroyed.
-		// Otherwise return the error
-		if !strings.Contains(err.Error(), "group does not exist") {
+		// A nil error means the group is still there, which is the failure this
+		// check exists to catch. Dereferencing err here used to panic instead.
+		if err == nil {
+			return fmt.Errorf("rule group %s/%s still exists in loki", namespace, name)
+		}
+		if !isNotFound(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
A first batch of contained fixes, mostly in the HTTP client and the test scaffolding. No resource behaviour changes, so this can land ahead of the larger `loki_rules` work.

### Credentials were written to the log by default

`debug` used `schema.EnvDefaultFunc("LOKI_DEBUG", true)`, and that second argument is what the function returns whenever the variable is unset — so debug was on for everyone who never touched it. Both dumps passed `true` as the body flag, so every request and response was written out in full: the `Authorization: Bearer …` header, basic auth, the SigV4 `X-Amz-Security-Token`, and the rule YAML. That only surfaces once `TF_LOG` is enabled, which is exactly the moment someone pastes their output into an issue.

`debug` now defaults to `false`, the dumps no longer include bodies, and credential headers are replaced with `[REDACTED]` even when debug is deliberately on. `TestRedactCredentials` pins which headers are stripped and, just as importantly, that the header names and the non-credential headers survive — a redaction that eats the whole dump is useless for debugging.

The proxy URL was also logged unconditionally on every provider init; it can carry credentials in userinfo, so it is now gated on `debug` like everything else.

### `log.Fatal` in the HTTP client took down the provider process

Three call sites in `sendRequest` called `log.Fatal`, which is `os.Exit(1)` inside the plugin: Terraform reports a plugin crash with no diagnostic, mid-apply, for every resource in flight. This was reachable — nothing validates `namespace`, and it is interpolated straight into the URL, so a namespace containing `%` makes `http.NewRequest` fail and kills the process. All three now return an error to the caller, which already wraps it in a diagnostic.

### `make test` panicked instead of running

`version.NewVersion(os.Getenv("LOKI_VERSION"))` returns a nil `*Version` when the variable is unset, and the next line called `LessThan` on it: SIGSEGV, whole package `FAIL`. CI never saw it because `make testacc` sets the variable. A `skipBelowLokiVersion` helper now skips rather than crashing, and skips via `t.Skipf` instead of the bare `return` that made a skipped gate report as a pass.

While there: `testAccCheckLokiRuleGroupDestroy` dereferenced `err` without checking it for nil, so it panicked precisely when the group had *not* been destroyed — the one case it exists to catch. It now reports that as a failure, and covers `loki_rule_group_alerting` too, which it silently skipped before.

### Smaller ones

- The computed user agent was passed to `p.UserAgent(...)` and the result discarded, so requests went out as `Go-http-client/1.1`. It is now actually sent.
- `caCertPool.AppendCertsFromPEM(caCert)` ignored its return value, so an unparseable `ca` produced an empty root pool and surfaced much later as an unrelated handshake failure. It is now rejected up front.
- `loki_rules` posted its YAML with no `Content-Type`, unlike the two typed resources. Loki does not inspect it, but the documented contract is `application/yaml` and intermediaries may not be as forgiving. The header value is now a shared constant rather than repeated in five places.
- `loki_rules` validated durations with `time.ParseDuration` while the rest of the provider uses `model.ParseDuration`, so `interval: 1d` and `for: 1w` were rejected at plan time even though Loki accepts them.
- `recordingRule` carried `json` struct tags on a type that is only ever YAML-marshalled. yaml.v3 ignores them and falls back to the lowercased field name, which happens to produce the right keys — it worked by coincidence and would break silently on the next field added.
- The 404 string match that four call sites duplicated is now a single `isNotFound` helper. Still a string match against the formatted error; making it a typed error is a separate change.