### PR TITLE
fix(loki_rules): stop dropping fields and actually delete removed groups

### DIFF
--- a/loki/resource_loki_rules.go
+++ b/loki/resource_loki_rules.go
@@ -1,9 +1,12 @@
 package loki
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"unicode/utf8"
@@ -22,27 +25,43 @@ type RuleGroups struct {
 	Groups []RuleGroup `yaml:"groups"`
 }
 
-// RuleGroup represents a single rule group
+// RuleGroup represents a single rule group. It models the whole surface Loki's
+// ruler accepts (Prometheus rulefmt), not just the parts the provider acts on:
+// the configuration is decoded into this type and marshalled back before being
+// sent, so any field missing here would be silently stripped from the user's
+// file. Fields Loki parses but discards are listed in droppedGroupFields.
 type RuleGroup struct {
-	Name     string `yaml:"name"`
-	Interval string `yaml:"interval,omitempty"`
-	Rules    []Rule `yaml:"rules"`
+	Name        string            `yaml:"name"`
+	Interval    string            `yaml:"interval,omitempty"`
+	Limit       int               `yaml:"limit,omitempty"`
+	QueryOffset string            `yaml:"query_offset,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Rules       []Rule            `yaml:"rules"`
 }
 
-// Rule represents both alerting and recording rules
+// Rule represents both alerting and recording rules. See RuleGroup on why every
+// accepted field is modelled.
 type Rule struct {
 	// Common fields
 	Expr   string            `yaml:"expr"`
 	Labels map[string]string `yaml:"labels,omitempty"`
 
 	// Alerting rule fields
-	Alert       string            `yaml:"alert,omitempty"`
-	For         string            `yaml:"for,omitempty"`
-	Annotations map[string]string `yaml:"annotations,omitempty"`
+	Alert         string            `yaml:"alert,omitempty"`
+	For           string            `yaml:"for,omitempty"`
+	KeepFiringFor string            `yaml:"keep_firing_for,omitempty"`
+	Annotations   map[string]string `yaml:"annotations,omitempty"`
 
 	// Recording rule fields
 	Record string `yaml:"record,omitempty"`
 }
+
+// Loki's ruler accepts these keys and answers 202, then drops them on the way
+// to storage: they are absent from rulespb.RuleGroupDesc/RuleDesc, so they
+// never reach evaluation. Accepting them silently would be a lie, and rejecting
+// a valid Prometheus file outright is unhelpful, so they warn.
+var droppedGroupFields = []string{"query_offset", labelsKey}
+var droppedRuleFields = []string{"keep_firing_for"}
 
 // resourcelokiRules creates the enhanced multi-group rules resource
 func resourcelokiRules() *schema.Resource {
@@ -185,72 +204,53 @@ func resourcelokiRules() *schema.Resource {
 				return err
 			}
 
-			// Calculate managed groups during plan phase for better diff output
-			if diff.HasChange("content") || diff.HasChange("content_file") || diff.HasChange("only_groups") || diff.HasChange("ignore_groups") || diff.Id() == "" {
-				// Parse the configuration to determine what will be managed
-				var ruleGroups RuleGroups
-				var err error
+			// Recomputed on every plan, not just when one of the inputs changed:
+			// editing a content_file in place changes no attribute, and a group
+			// deleted out of band only shows up in the refreshed content_hash.
+			// Gating this on HasChange made both produce an empty plan.
+			ruleGroups, err := parseRuleGroupsForDiff(diff)
+			if err != nil || len(ruleGroups.Groups) == 0 {
+				return nil //nolint:nilerr
+			}
 
-				if content := diff.Get("content").(string); content != "" {
-					err = yaml.Unmarshal([]byte(content), &ruleGroups)
-				} else if contentFile := diff.Get("content_file").(string); contentFile != "" {
-					data, readErr := os.ReadFile(contentFile)
-					if readErr == nil {
-						err = yaml.Unmarshal(data, &ruleGroups)
+			only, _ := diff.Get("only_groups").(*schema.Set)
+			ignore, _ := diff.Get("ignore_groups").(*schema.Set)
+			managedGroups := selectManagedGroups(ruleGroups, only, ignore)
+
+			// Set the computed fields so they appear in the plan
+			if err := diff.SetNew("managed_groups", managedGroups); err != nil {
+				return err
+			}
+			if err := diff.SetNew("groups_count", len(managedGroups)); err != nil {
+				return err
+			}
+
+			totalRules := 0
+			var ruleNames []string
+			for _, group := range ruleGroups.Groups {
+				if !contains(managedGroups, group.Name) {
+					continue
+				}
+				totalRules += len(group.Rules)
+				for _, rule := range group.Rules {
+					if rule.Alert != "" {
+						ruleNames = append(ruleNames, rule.Alert)
+					} else if rule.Record != "" {
+						ruleNames = append(ruleNames, rule.Record)
 					}
 				}
+			}
+			if err := diff.SetNew("total_rules", totalRules); err != nil {
+				return err
+			}
+			if err := diff.SetNew("rule_names", ruleNames); err != nil {
+				return err
+			}
 
-				if err == nil && len(ruleGroups.Groups) > 0 {
-					// Determine which groups will be managed
-					allGroupNames := make([]string, len(ruleGroups.Groups))
-					for i, group := range ruleGroups.Groups {
-						allGroupNames[i] = group.Name
-					}
-
-					var managedGroups []string
-					if onlyGroups := diff.Get("only_groups").(*schema.Set); onlyGroups != nil && onlyGroups.Len() > 0 {
-						for _, name := range onlyGroups.List() {
-							groupName := name.(string)
-							if contains(allGroupNames, groupName) {
-								managedGroups = append(managedGroups, groupName)
-							}
-						}
-					} else if ignoreGroups := diff.Get("ignore_groups").(*schema.Set); ignoreGroups != nil && ignoreGroups.Len() > 0 {
-						var ignored []string
-						for _, name := range ignoreGroups.List() {
-							ignored = append(ignored, name.(string))
-						}
-						for _, groupName := range allGroupNames {
-							if !contains(ignored, groupName) {
-								managedGroups = append(managedGroups, groupName)
-							}
-						}
-					} else {
-						managedGroups = allGroupNames
-					}
-
-					// Set the computed fields so they appear in the plan
-					diff.SetNew("managed_groups", managedGroups)
-					diff.SetNew("groups_count", len(managedGroups))
-
-					// Calculate total rules and collect rule names
-					totalRules := 0
-					var ruleNames []string
-					for _, group := range ruleGroups.Groups {
-						if contains(managedGroups, group.Name) {
-							totalRules += len(group.Rules)
-							for _, rule := range group.Rules {
-								if rule.Alert != "" {
-									ruleNames = append(ruleNames, rule.Alert)
-								} else if rule.Record != "" {
-									ruleNames = append(ruleNames, rule.Record)
-								}
-							}
-						}
-					}
-					diff.SetNew("total_rules", totalRules)
-					diff.SetNew("rule_names", ruleNames)
-				}
+			// The hash is what makes an edited content_file, or a group deleted
+			// behind Terraform's back, visible as a diff.
+			if err := diff.SetNew("content_hash", calculateContentHash(ruleGroups, managedGroups)); err != nil {
+				return err
 			}
 
 			return nil
@@ -267,11 +267,12 @@ func validateYAMLContent(val interface{}, key string) (warns []string, errs []er
 		return
 	}
 
-	var ruleGroups RuleGroups
-	if err := yaml.Unmarshal([]byte(content), &ruleGroups); err != nil {
+	ruleGroups, err := decodeRuleGroups([]byte(content))
+	if err != nil {
 		errs = append(errs, fmt.Errorf("%q contains invalid YAML: %v", key, err))
 		return
 	}
+	warns = append(warns, warnDroppedFields([]byte(content))...)
 
 	if err := validateRuleGroupsContent(ruleGroups); err != nil {
 		errs = append(errs, fmt.Errorf("%q validation failed: %v", key, err))
@@ -411,7 +412,65 @@ func validateRuleGroupsConfiguration(diff *schema.ResourceDiff) error {
 		return fmt.Errorf("'content' and 'content_file' are mutually exclusive")
 	}
 
+	return validateGroupFilters(diff)
+}
+
+// validateGroupFilters rejects names in only_groups/ignore_groups that no group
+// in the configuration carries. Unknown names used to be dropped silently; now
+// that removing a group actually deletes it from Loki, a typo in only_groups
+// would mean "manage nothing, delete everything that was managed".
+func validateGroupFilters(diff *schema.ResourceDiff) error {
+	ruleGroups, err := parseRuleGroupsForDiff(diff)
+	if err != nil || len(ruleGroups.Groups) == 0 {
+		// Content problems are reported by the content validators themselves.
+		return nil //nolint:nilerr
+	}
+
+	declared := make([]string, len(ruleGroups.Groups))
+	for i, group := range ruleGroups.Groups {
+		declared[i] = group.Name
+	}
+
+	only, _ := diff.Get("only_groups").(*schema.Set)
+	ignore, _ := diff.Get("ignore_groups").(*schema.Set)
+	return validateGroupFilterNames(declared, only, ignore)
+}
+
+func validateGroupFilterNames(declared []string, only, ignore *schema.Set) error {
+	for _, filter := range []struct {
+		key string
+		set *schema.Set
+	}{{"only_groups", only}, {"ignore_groups", ignore}} {
+		if filter.set == nil {
+			continue
+		}
+		for _, raw := range filter.set.List() {
+			name := raw.(string)
+			if !contains(declared, name) {
+				return fmt.Errorf(
+					"%s contains %q, which is not a rule group in the configuration (declared groups: %s)",
+					filter.key, name, strings.Join(declared, ", "))
+			}
+		}
+	}
+
 	return nil
+}
+
+// parseRuleGroupsForDiff decodes the configured rule groups from a diff, which
+// unlike ResourceData is what CustomizeDiff has to work with.
+func parseRuleGroupsForDiff(diff *schema.ResourceDiff) (RuleGroups, error) {
+	if content := diff.Get("content").(string); content != "" {
+		return decodeRuleGroups([]byte(content))
+	}
+	if contentFile := diff.Get("content_file").(string); contentFile != "" {
+		data, err := os.ReadFile(contentFile)
+		if err != nil {
+			return RuleGroups{}, err
+		}
+		return decodeRuleGroups(data)
+	}
+	return RuleGroups{}, fmt.Errorf("no rule configuration provided")
 }
 
 // Resource CRUD operations
@@ -521,7 +580,12 @@ func resourcelokiRulesUpdate(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
-	oldManagedGroups := d.Get("managed_groups").([]interface{})
+	// CustomizeDiff already called SetNew("managed_groups", ...), so d.Get here
+	// returns the new value and difference(old, new) was always empty: removing
+	// a group from the configuration never deleted it from Loki. GetChange is
+	// what actually reaches the prior state.
+	oldManagedGroupsRaw, _ := d.GetChange("managed_groups")
+	oldManagedGroups := oldManagedGroupsRaw.([]interface{})
 	newManagedGroups := determineGroupsToManage(newRuleGroups, d)
 
 	// Convert old managed groups to string slice
@@ -607,19 +671,37 @@ func resourcelokiRulesImport(ctx context.Context, d *schema.ResourceData, m inte
 
 // Helper functions
 
-func parseRuleGroupsConfiguration(d *schema.ResourceData) (RuleGroups, error) {
+// decodeRuleGroups parses rule groups with KnownFields enabled, so a key the
+// provider does not model is reported instead of being dropped on the floor.
+func decodeRuleGroups(data []byte) (RuleGroups, error) {
 	var ruleGroups RuleGroups
 
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&ruleGroups); err != nil {
+		if errors.Is(err, io.EOF) {
+			return ruleGroups, fmt.Errorf("rule configuration is empty")
+		}
+		return ruleGroups, err
+	}
+
+	return ruleGroups, nil
+}
+
+func parseRuleGroupsConfiguration(d *schema.ResourceData) (RuleGroups, error) {
+	var ruleGroups RuleGroups
+	var err error
+
 	if content := d.Get("content").(string); content != "" {
-		if err := yaml.Unmarshal([]byte(content), &ruleGroups); err != nil {
+		if ruleGroups, err = decodeRuleGroups([]byte(content)); err != nil {
 			return ruleGroups, fmt.Errorf("failed to parse YAML content: %w", err)
 		}
 	} else if contentFile := d.Get("content_file").(string); contentFile != "" {
-		data, err := os.ReadFile(contentFile)
-		if err != nil {
-			return ruleGroups, fmt.Errorf("failed to read file %s: %w", contentFile, err)
+		data, readErr := os.ReadFile(contentFile)
+		if readErr != nil {
+			return ruleGroups, fmt.Errorf("failed to read file %s: %w", contentFile, readErr)
 		}
-		if err := yaml.Unmarshal(data, &ruleGroups); err != nil {
+		if ruleGroups, err = decodeRuleGroups(data); err != nil {
 			return ruleGroups, fmt.Errorf("failed to parse YAML file %s: %w", contentFile, err)
 		}
 	} else {
@@ -629,16 +711,70 @@ func parseRuleGroupsConfiguration(d *schema.ResourceData) (RuleGroups, error) {
 	return ruleGroups, validateRuleGroupsContent(ruleGroups)
 }
 
+// warnDroppedFields reports the fields Loki accepts and then discards, so the
+// user hears about it at plan time rather than wondering why the rule behaves
+// differently than the file says.
+func warnDroppedFields(data []byte) []string {
+	var raw struct {
+		Groups []map[string]interface{} `yaml:"groups"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+
+	var warns []string
+	seen := map[string]bool{}
+	report := func(field string) {
+		if seen[field] {
+			return
+		}
+		seen[field] = true
+		warns = append(warns, fmt.Sprintf(
+			"%q is accepted by Loki's ruler but discarded before evaluation, so it will have no effect", field))
+	}
+
+	for _, group := range raw.Groups {
+		for _, field := range droppedGroupFields {
+			if _, ok := group[field]; ok {
+				report(field)
+			}
+		}
+		rules, _ := group["rules"].([]interface{})
+		for _, r := range rules {
+			rule, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for _, field := range droppedRuleFields {
+				if _, ok := rule[field]; ok {
+					report(field)
+				}
+			}
+		}
+	}
+
+	return warns
+}
+
 func determineGroupsToManage(ruleGroups RuleGroups, d *schema.ResourceData) []string {
+	only, _ := d.Get("only_groups").(*schema.Set)
+	ignore, _ := d.Get("ignore_groups").(*schema.Set)
+	return selectManagedGroups(ruleGroups, only, ignore)
+}
+
+// selectManagedGroups applies only_groups/ignore_groups to the declared groups.
+// CustomizeDiff and the CRUD functions both go through it, so the plan and the
+// apply cannot disagree on what is managed.
+func selectManagedGroups(ruleGroups RuleGroups, only, ignore *schema.Set) []string {
 	allGroupNames := make([]string, len(ruleGroups.Groups))
 	for i, group := range ruleGroups.Groups {
 		allGroupNames[i] = group.Name
 	}
 
 	// If specific groups are named, use only those
-	if onlyGroups := d.Get("only_groups").(*schema.Set); onlyGroups.Len() > 0 {
+	if only != nil && only.Len() > 0 {
 		var selected []string
-		for _, name := range onlyGroups.List() {
+		for _, name := range only.List() {
 			groupName := name.(string)
 			if contains(allGroupNames, groupName) {
 				selected = append(selected, groupName)
@@ -648,9 +784,9 @@ func determineGroupsToManage(ruleGroups RuleGroups, d *schema.ResourceData) []st
 	}
 
 	// If ignore_groups is set, exclude those
-	if ignoreGroups := d.Get("ignore_groups").(*schema.Set); ignoreGroups.Len() > 0 {
+	if ignore != nil && ignore.Len() > 0 {
 		var ignored []string
-		for _, name := range ignoreGroups.List() {
+		for _, name := range ignore.List() {
 			ignored = append(ignored, name.(string))
 		}
 

--- a/loki/resource_loki_rules_test.go
+++ b/loki/resource_loki_rules_test.go
@@ -96,6 +96,43 @@ func TestAccResourceRules_multipleGroups(t *testing.T) {
 	})
 }
 
+// Removing a group from the configuration must delete it from Loki. Update read
+// managed_groups through d.Get, which CustomizeDiff had already overwritten with
+// the new value, so the delete list was always empty and the group was orphaned
+// while Terraform reported success.
+func TestAccResourceRules_removeGroup(t *testing.T) {
+	// Init client
+	client, err := NewAPIClient(setupClient())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckLokiRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceRulesConfig_removeGroup_v1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLokiNamespaceExists("loki_rules.remove", "remove", client),
+					resource.TestCheckResourceAttr("loki_rules.remove", "managed_groups.#", "2"),
+					resource.TestCheckResourceAttr("loki_rules.remove", "groups_count", "2"),
+				),
+			},
+			{
+				Config: testAccResourceRulesConfig_removeGroup_v2,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("loki_rules.remove", "managed_groups.#", "1"),
+					resource.TestCheckResourceAttr("loki_rules.remove", "managed_groups.0", "kept_group"),
+					resource.TestCheckResourceAttr("loki_rules.remove", "groups_count", "1"),
+					testAccCheckLokiRuleGroupGone("test_remove", "dropped_group", client),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceRules_onlyGroups(t *testing.T) {
 	// Init client
 	client, err := NewAPIClient(setupClient())
@@ -479,6 +516,42 @@ resource "loki_rules" "with_org" {
           - alert: OrgAlert
             expr: |
               count_over_time({job="test"} [5m]) == 0
+  EOT
+}
+`
+
+const testAccResourceRulesConfig_removeGroup_v1 = `
+resource "loki_rules" "remove" {
+  namespace = "test_remove"
+
+  content = <<-EOT
+    groups:
+      - name: kept_group
+        interval: 1m
+        rules:
+          - record: job:kept:5m
+            expr: sum(rate({job=~".+"}[5m])) by (job)
+
+      - name: dropped_group
+        interval: 1m
+        rules:
+          - record: job:dropped:5m
+            expr: sum(rate({job=~".+"}[5m])) by (job)
+  EOT
+}
+`
+
+const testAccResourceRulesConfig_removeGroup_v2 = `
+resource "loki_rules" "remove" {
+  namespace = "test_remove"
+
+  content = <<-EOT
+    groups:
+      - name: kept_group
+        interval: 1m
+        rules:
+          - record: job:kept:5m
+            expr: sum(rate({job=~".+"}[5m])) by (job)
   EOT
 }
 `

--- a/loki/rulefmt_fields_test.go
+++ b/loki/rulefmt_fields_test.go
@@ -1,0 +1,178 @@
+package loki
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"gopkg.in/yaml.v3"
+)
+
+// The resource decodes the user's YAML and marshals it back before posting, so
+// a field it does not model is stripped without a word. limit is the one that
+// Loki actually persists, so losing it changes evaluation.
+func TestRuleGroupsRoundTripKeepsEveryAcceptedField(t *testing.T) {
+	content := `
+groups:
+  - name: group_1
+    interval: 1m
+    limit: 10
+    query_offset: 5m
+    labels:
+      team: obs
+    rules:
+      - alert: test_alert
+        expr: '{app="foo"} |= "error"'
+        for: 5m
+        keep_firing_for: 10m
+        labels:
+          severity: page
+        annotations:
+          summary: something broke
+      - record: recorded:metric
+        expr: 'sum(rate({app="foo"}[5m]))'
+        labels:
+          team: obs
+`
+
+	groups, err := decodeRuleGroups([]byte(content))
+	if err != nil {
+		t.Fatalf("unexpected decode error: %s", err)
+	}
+
+	out, err := yaml.Marshal(groups.Groups[0])
+	if err != nil {
+		t.Fatalf("unexpected marshal error: %s", err)
+	}
+
+	for _, want := range []string{
+		"limit: 10", "query_offset: 5m", "keep_firing_for: 10m",
+		"team: obs", "severity: page", "summary: something broke",
+		"interval: 1m", "record: recorded:metric",
+	} {
+		if !strings.Contains(string(out), want) {
+			t.Errorf("round-trip dropped %q:\n%s", want, out)
+		}
+	}
+}
+
+// A key the provider does not model must be reported, not ignored: silently
+// dropping it is what this whole resource must never do.
+func TestDecodeRuleGroupsRejectsUnknownField(t *testing.T) {
+	content := `
+groups:
+  - name: group_1
+    intervall: 1m
+    rules:
+      - record: recorded:metric
+        expr: 'sum(rate({app="foo"}[5m]))'
+`
+
+	_, err := decodeRuleGroups([]byte(content))
+	if err == nil {
+		t.Fatal("expected an error for the unknown field 'intervall'")
+	}
+	if !strings.Contains(err.Error(), "intervall") {
+		t.Errorf("error should name the offending field, got: %s", err)
+	}
+}
+
+func TestDecodeRuleGroupsRejectsEmptyContent(t *testing.T) {
+	if _, err := decodeRuleGroups([]byte("")); err == nil {
+		t.Fatal("expected an error for empty content")
+	}
+}
+
+// Loki answers 202 for these and then drops them, so they warn rather than
+// failing a configuration that is perfectly valid Prometheus.
+func TestWarnDroppedFields(t *testing.T) {
+	content := `
+groups:
+  - name: group_1
+    query_offset: 5m
+    labels:
+      team: obs
+    rules:
+      - alert: test_alert
+        expr: '{app="foo"} |= "error"'
+        keep_firing_for: 10m
+`
+
+	warns := warnDroppedFields([]byte(content))
+	for _, want := range []string{"query_offset", labelsKey, "keep_firing_for"} {
+		found := false
+		for _, w := range warns {
+			if strings.Contains(w, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected a warning about %q, got %v", want, warns)
+		}
+	}
+
+	if warns := warnDroppedFields([]byte(`
+groups:
+  - name: group_1
+    interval: 1m
+    rules:
+      - record: recorded:metric
+        expr: 'sum(rate({app="foo"}[5m]))'
+`)); len(warns) != 0 {
+		t.Errorf("expected no warnings for a plain group, got %v", warns)
+	}
+}
+
+// A typo here used to be ignored. Now that removing a group deletes it, that
+// would mean "manage nothing, delete everything previously managed".
+func TestValidateGroupFilterNamesRejectsUnknownGroup(t *testing.T) {
+	declared := []string{"group_1", "group_2"}
+	set := func(names ...string) *schema.Set {
+		items := make([]interface{}, len(names))
+		for i, n := range names {
+			items[i] = n
+		}
+		return schema.NewSet(schema.HashString, items)
+	}
+
+	if err := validateGroupFilterNames(declared, set("group_1"), nil); err != nil {
+		t.Errorf("a declared group must be accepted, got: %s", err)
+	}
+	if err := validateGroupFilterNames(declared, nil, nil); err != nil {
+		t.Errorf("no filter must be accepted, got: %s", err)
+	}
+
+	err := validateGroupFilterNames(declared, set("group_1", "gruop_2"), nil)
+	if err == nil {
+		t.Fatal("expected an error for a group name that is not declared")
+	}
+	if !strings.Contains(err.Error(), "gruop_2") {
+		t.Errorf("error should name the offending group, got: %s", err)
+	}
+
+	if err := validateGroupFilterNames(declared, nil, set("nope")); err == nil {
+		t.Error("expected ignore_groups to be validated too")
+	}
+}
+
+// Loki parses durations with prometheus/common/model, which accepts 1d and 1w.
+func TestValidateRuleGroupsContentAllowsPrometheusDurations(t *testing.T) {
+	content := `
+groups:
+  - name: group_1
+    interval: 1d
+    rules:
+      - alert: test_alert
+        expr: '{app="foo"} |= "error"'
+        for: 1w
+`
+
+	groups, err := decodeRuleGroups([]byte(content))
+	if err != nil {
+		t.Fatalf("unexpected decode error: %s", err)
+	}
+	if err := validateRuleGroupsContent(groups); err != nil {
+		t.Fatalf("1d/1w must be accepted, got: %s", err)
+	}
+}

--- a/loki/shared_test.go
+++ b/loki/shared_test.go
@@ -112,6 +112,29 @@ func testAccCheckLokiNamespaceExists(n string, name string, client *apiClient) r
 	}
 }
 
+// testAccCheckLokiRuleGroupGone asserts a rule group is absent from Loki itself,
+// not merely absent from the Terraform state: state can say a group is no longer
+// managed while the group is still sitting in the backend.
+func testAccCheckLokiRuleGroupGone(namespace, name string, client *apiClient) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		headers := make(map[string]string)
+		if orgID := os.Getenv("LOKI_ORG_ID"); orgID != "" {
+			headers["X-Scope-OrgID"] = orgID
+		}
+
+		path := fmt.Sprintf("%s/%s/%s", rulesPath, namespace, name)
+		_, err := client.sendRequest("GET", path, "", headers)
+		if err == nil {
+			return fmt.Errorf("rule group %s/%s still exists in loki", namespace, name)
+		}
+		if !isNotFound(err) {
+			return err
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckLokiRuleGroupDestroy(s *terraform.State) error {
 	// retrieve the connection established in Provider configuration
 	client := testAccProvider.Meta().(*apiClient)

--- a/loki/shared_test.go
+++ b/loki/shared_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -121,17 +122,28 @@ func testAccCheckLokiRuleGroupGone(namespace, name string, client *apiClient) re
 		if orgID := os.Getenv("LOKI_ORG_ID"); orgID != "" {
 			headers["X-Scope-OrgID"] = orgID
 		}
-
 		path := fmt.Sprintf("%s/%s/%s", rulesPath, namespace, name)
-		_, err := client.sendRequest("GET", path, "", headers)
-		if err == nil {
-			return fmt.Errorf("rule group %s/%s still exists in loki", namespace, name)
-		}
-		if !isNotFound(err) {
-			return err
+
+		// The ruler persists to object storage, so a group is not necessarily
+		// gone the instant the DELETE returns. Poll rather than assert once.
+		var lastErr error
+		for attempt := 0; attempt < 10; attempt++ {
+			if attempt > 0 {
+				time.Sleep(time.Second)
+			}
+
+			_, err := client.sendRequest("GET", path, "", headers)
+			switch {
+			case err == nil:
+				lastErr = fmt.Errorf("rule group %s/%s still exists in loki", namespace, name)
+			case isNotFound(err):
+				return nil
+			default:
+				lastErr = err
+			}
 		}
 
-		return nil
+		return lastErr
 	}
 }
 


### PR DESCRIPTION
`loki_rules` is documented as managing a YAML file of rule groups, but it does not send that file: it decodes it into a reduced Go struct and marshals the struct back before posting. Anything the struct does not model is stripped in between, without an error and without a diff. It also never deleted a group once one was removed from the file, and never planned anything when the file was edited in place.

### Nothing is dropped silently any more

`RuleGroup` modelled `name`, `interval` and `rules`; `Rule` modelled six fields. Everything else vanished. That includes `limit`, which Loki genuinely honours — `rulespb.ToProto` copies it into `RuleGroupDesc` — so a group with `limit: 10` was evaluated without its limit and nothing said so.

Both types now model the full surface the ruler accepts, and decoding uses `KnownFields(true)`, so a key the provider does not recognise is an error naming the key instead of a silent drop. **This is a behaviour change**: a configuration carrying a stray or misspelled key used to apply cleanly and will now fail at plan time. That is the point — but it is worth knowing before upgrading.

Three fields sit in between. `keep_firing_for`, `query_offset` and group-level `labels` are accepted by the ruler, which answers 202, and then dropped on the way to storage: they are absent from `RuleGroupDesc`/`RuleDesc`, so they never reach evaluation. Rejecting a perfectly valid Prometheus file over them would be unhelpful, and accepting them silently would be a lie, so they now produce a plan-time warning. They are still modelled and still round-trip, so nothing is lost from the user's file.

This also confirms that keeping `keep_firing_for` commented out on `loki_rule_group_alerting` was the right call, for a reason worth writing down: it is not that Loki rejects it, it is that Loki accepts it and ignores it.

### Removing a group from the file now deletes it

`Update` read the previous group list with `d.Get("managed_groups")`. `CustomizeDiff` has already called `SetNew` on that attribute by then, so `d.Get` returned the *new* list and `difference(old, new)` was invariably empty. No `DELETE` was ever issued: the group stayed in Loki, unmanaged and untracked, while the apply reported success. It now reads through `d.GetChange`.

That fix cannot land on its own. Unknown names in `only_groups`/`ignore_groups` were silently ignored, which was harmless only because nothing was ever deleted — with deletion working, a single typo in `only_groups` means "manage nothing, and delete everything previously managed". Unknown names are now rejected, naming the offending entry and listing the groups actually declared.

### An edited `content_file` produces a plan again

`CustomizeDiff` only recomputed when one of `content`, `content_file`, `only_groups` or `ignore_groups` had changed. Editing the file the resource points at changes no attribute, so the plan came out empty and the new rules were never pushed. The same gate hid out-of-band deletions: `Read` recomputes `content_hash` over the groups that still exist, but nothing ever compared it against the configuration.

The computed fields, `content_hash` included, are now recalculated on every plan. The group-selection logic is shared between the diff and the CRUD functions, so the plan and the apply cannot disagree about what is managed.

### Tests

Unit tests cover the round-trip of every accepted field, the rejection of an unknown key, the warnings, the `only_groups` guard, and that `1d`/`1w` durations are accepted. An acceptance test covers the group removal end to end, with a `testAccCheckLokiRuleGroupGone` helper that checks the backend rather than the state — the distinction that let this bug live.

Import remains broken and is deliberately left out; it needs its own change.